### PR TITLE
[Hong & Song] feature-PhotosLibrary - 포토 앨범 가져와서 뿌려주기

### DIFF
--- a/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
+++ b/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
@@ -20,7 +20,7 @@
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="3d3-KP-sgh">
                                 <rect key="frame" x="0.0" y="88" width="390" height="722"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="d77-u8-Vgi">
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="d77-u8-Vgi">
                                     <size key="itemSize" width="128" height="128"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>

--- a/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
+++ b/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="50F-os-Mox">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
@@ -9,7 +9,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Photos-->
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="PhotosApp" customModuleProvider="target" sceneMemberID="viewController">
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="3d3-KP-sgh">
-                                <rect key="frame" x="0.0" y="44" width="390" height="766"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="722"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="d77-u8-Vgi">
                                     <size key="itemSize" width="128" height="128"/>
@@ -47,11 +47,30 @@
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="3d3-KP-sgh" secondAttribute="trailing" id="vzq-Ez-ooC"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" title="Photos" id="UpF-iQ-GhS"/>
                     <connections>
                         <outlet property="collectionView" destination="3d3-KP-sgh" id="yB0-MB-Gdf"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1040" y="88.151658767772503"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="jqs-oK-HnD">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="50F-os-Mox" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="G3d-Ad-sBS">
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="Ojg-QX-X8e"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="n9B-No-57N" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="110.76923076923076" y="88.151658767772503"/>
         </scene>

--- a/PhotosApp/PhotosApp/ColorCell.swift
+++ b/PhotosApp/PhotosApp/ColorCell.swift
@@ -14,6 +14,7 @@ class ColorCell: UICollectionViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
+        imageView.contentMode = .scaleAspectFill
     }
 
     static func nib() -> UINib {

--- a/PhotosApp/PhotosApp/ColorCell.swift
+++ b/PhotosApp/PhotosApp/ColorCell.swift
@@ -14,7 +14,6 @@ class ColorCell: UICollectionViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        self.backgroundColor = UIColor.random
     }
 
     static func nib() -> UINib {

--- a/PhotosApp/PhotosApp/ColorCell.swift
+++ b/PhotosApp/PhotosApp/ColorCell.swift
@@ -10,7 +10,7 @@ import UIKit
 class ColorCell: UICollectionViewCell {
     @IBOutlet weak var imageView: UIImageView!
     
-    static let identifier = "ColorCell"
+    var identifier = "ColorCell"
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -18,6 +18,6 @@ class ColorCell: UICollectionViewCell {
     }
 
     static func nib() -> UINib {
-        return UINib(nibName: ColorCell.identifier, bundle: nil)
+        return UINib(nibName: ColorCell().identifier, bundle: nil)
     }
 }

--- a/PhotosApp/PhotosApp/ColorCell.swift
+++ b/PhotosApp/PhotosApp/ColorCell.swift
@@ -8,7 +8,8 @@
 import UIKit
 
 class ColorCell: UICollectionViewCell {
-
+    @IBOutlet weak var imageView: UIImageView!
+    
     static let identifier = "ColorCell"
     
     override func awakeFromNib() {

--- a/PhotosApp/PhotosApp/ColorCell.xib
+++ b/PhotosApp/PhotosApp/ColorCell.xib
@@ -10,14 +10,18 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="ColorCell" customModule="PhotosApp" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+            <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bda-ew-Ead">
-                        <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                        <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="100" id="c5n-oY-D8w"/>
+                            <constraint firstAttribute="height" constant="100" id="gaq-Ai-RZ3"/>
+                        </constraints>
                     </imageView>
                 </subviews>
             </view>

--- a/PhotosApp/PhotosApp/ColorCell.xib
+++ b/PhotosApp/PhotosApp/ColorCell.xib
@@ -15,8 +15,22 @@
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                 <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <subviews>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bda-ew-Ead">
+                        <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                    </imageView>
+                </subviews>
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="bda-ew-Ead" secondAttribute="trailing" id="BDf-Ji-PRH"/>
+                <constraint firstItem="bda-ew-Ead" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="Fok-RN-4Gs"/>
+                <constraint firstAttribute="bottom" secondItem="bda-ew-Ead" secondAttribute="bottom" id="Slt-Nw-xOm"/>
+                <constraint firstItem="bda-ew-Ead" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="dqx-iH-j5M"/>
+            </constraints>
+            <connections>
+                <outlet property="imageView" destination="bda-ew-Ead" id="khq-eM-knX"/>
+            </connections>
             <point key="canvasLocation" x="139" y="104"/>
         </collectionViewCell>
     </objects>

--- a/PhotosApp/PhotosApp/ColorCell.xib
+++ b/PhotosApp/PhotosApp/ColorCell.xib
@@ -18,10 +18,6 @@
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bda-ew-Ead">
                         <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="100" id="c5n-oY-D8w"/>
-                            <constraint firstAttribute="height" constant="100" id="gaq-Ai-RZ3"/>
-                        </constraints>
                     </imageView>
                 </subviews>
             </view>

--- a/PhotosApp/PhotosApp/Info.plist
+++ b/PhotosApp/PhotosApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>사진을 사용합니다.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -16,7 +16,7 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        collectionView.register(ColorCell.nib(), forCellWithReuseIdentifier: ColorCell.identifier)
+        collectionView.register(ColorCell.nib(), forCellWithReuseIdentifier: ColorCell().identifier)
         collectionView.dataSource = self
         collectionView.delegate = self
         
@@ -32,10 +32,15 @@ extension ViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let asset = allPhotos.object(at: indexPath.item)
-        var cell = ColorCell()
+      
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ColorCell", for: indexPath) as! ColorCell
+        cell.identifier = asset.localIdentifier
         imageManager.requestImage(for: asset, targetSize: CGSize(width: 50.0, height: 50.0), contentMode: .aspectFill, options: nil) { image, _ in
-            cell = collectionView.dequeueReusableCell(withReuseIdentifier: ColorCell.identifier, for: indexPath) as! ColorCell
-            cell.imageView = UIImageView(image: image)
+            
+            if cell.identifier == asset.localIdentifier {
+
+                cell.imageView.image = image
+            }
         }
         return cell
     }

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -38,13 +38,10 @@ extension ViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let asset = allPhotos.object(at: indexPath.item)
-        let option = PHImageRequestOptions()
-   
-        option.resizeMode = .exact
    
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ColorCell", for: indexPath) as! ColorCell
         cell.identifier = asset.localIdentifier
-        imageManager.requestImage(for: asset, targetSize: CGSize(width: 100.0, height: 100.0), contentMode: .aspectFill, options: option) { image, _ in
+        imageManager.requestImage(for: asset, targetSize: CGSize(width: 100.0, height: 100.0), contentMode: .aspectFill, options: .none) { image, _ in
             
             if cell.identifier == asset.localIdentifier {
 

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -21,6 +21,12 @@ class ViewController: UIViewController {
         collectionView.delegate = self
         
         allPhotos = PHAsset.fetchAssets(with: nil)
+        
+        PHPhotoLibrary.shared().register(self)
+    }
+    
+    deinit {
+        PHPhotoLibrary.shared().unregisterChangeObserver(self)
     }
 }
 
@@ -56,3 +62,24 @@ extension ViewController: UICollectionViewDelegateFlowLayout {
     }
 }
 
+extension ViewController: PHPhotoLibraryChangeObserver {
+    func photoLibraryDidChange(_ changeInstance: PHChange) {
+        
+        guard let changes = changeInstance.changeDetails(for: allPhotos) else { return }
+        
+        DispatchQueue.main.sync {
+            allPhotos = changes.fetchResultAfterChanges
+            if changes.hasIncrementalChanges {
+                if let removed = changes.removedIndexes, !removed.isEmpty {
+                    print("removed")
+                }
+                if let inserted = changes.insertedIndexes, !inserted.isEmpty {
+                    print("inserted")
+                }
+                changes.enumerateMoves { fromIndex, toIndex in
+                    print("moves")
+                }
+            }
+        }
+    }
+}

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -32,10 +32,13 @@ extension ViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let asset = allPhotos.object(at: indexPath.item)
-      
+        let option = PHImageRequestOptions()
+   
+        option.resizeMode = .exact
+   
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ColorCell", for: indexPath) as! ColorCell
         cell.identifier = asset.localIdentifier
-        imageManager.requestImage(for: asset, targetSize: CGSize(width: 50.0, height: 50.0), contentMode: .aspectFill, options: nil) { image, _ in
+        imageManager.requestImage(for: asset, targetSize: CGSize(width: 100.0, height: 100.0), contentMode: .aspectFill, options: option) { image, _ in
             
             if cell.identifier == asset.localIdentifier {
 

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -12,6 +12,7 @@ class ViewController: UIViewController {
  
     @IBOutlet weak var collectionView: UICollectionView!
     var allPhotos: PHFetchResult<PHAsset>!
+    let imageManager = PHCachingImageManager()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -31,15 +32,18 @@ extension ViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let asset = allPhotos.object(at: indexPath.item)
-        
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ColorCell.identifier, for: indexPath) as! ColorCell
+        var cell = ColorCell()
+        imageManager.requestImage(for: asset, targetSize: CGSize(width: 50.0, height: 50.0), contentMode: .aspectFill, options: nil) { image, _ in
+            cell = collectionView.dequeueReusableCell(withReuseIdentifier: ColorCell.identifier, for: indexPath) as! ColorCell
+            cell.imageView = UIImageView(image: image)
+        }
         return cell
     }
 }
 
 extension ViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let size = CGSize(width: 80.0, height: 80.0)
+        let size = CGSize(width: 100.0, height: 100.0)
         return size
     }
 }

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -6,26 +6,31 @@
 //
 
 import UIKit
+import Photos
 
 class ViewController: UIViewController {
  
     @IBOutlet weak var collectionView: UICollectionView!
+    var allPhotos: PHFetchResult<PHAsset>!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         collectionView.register(ColorCell.nib(), forCellWithReuseIdentifier: ColorCell.identifier)
         collectionView.dataSource = self
         collectionView.delegate = self
+        
+        allPhotos = PHAsset.fetchAssets(with: nil)
     }
 }
 
 extension ViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 40
+        return allPhotos.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let asset = allPhotos.object(at: indexPath.item)
         
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ColorCell.identifier, for: indexPath) as! ColorCell
         return cell


### PR DESCRIPTION
#### 작업 목록
- [x] 네비게이션 컨트롤러 임베드
- [x] PHAsset 프레임워크 사용해서 사진 보관함에 있는 사진을 셀에 표시
- [x] PHCachingImageManager를 사용해서 이미지 크기 조정
- [x] PHPhotoLibrary 클래스를 이용해서 사진 보관함 변경 여부 확인

#### 학습 키워드
- Photos

#### 고민과 해결
- 이미지 크기 - Xib를 사용한 버전과 스토리보드를 사용한 버전을 모두 시도해보았는데, Xib의 경우 Image request option에서 resizeMode를 .exact로 주지 않으면 target size가 제대로 나오지 않는 문제가 있는 것을 확인했습니다.